### PR TITLE
FIX: provide correct did:web resolver configuration

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -48,7 +48,7 @@ export const didResolver = new Resolver({
   ...getUniResolver(SupportedDidMethodEnum.DID_ETHR, {
     resolveUrl: DIF_UNIRESOLVER_RESOLVE_URL,
   }),
-  ...webDIDResolver,
+  ...webDIDResolver(),
   ...getDidIonResolver(),
   ...getDidJwkResolver(),
 });


### PR DESCRIPTION
Hello,

SSI Wallet fails verify credentials when issuer uses `did:web` method.
Wallet throws `unsupportedDIDMethod` error that originates from the instance of the `Resolver` when mapping is not found.

`web-did-resolver` resolver is not provided correctly.